### PR TITLE
build.gradle.kts内でのproguard設定の修正

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,7 +99,8 @@ android {
             val files = rootProject.file("proguard")
                     .listFiles()
                     .filter { it.name.startsWith("proguard") }
-            setProguardFiles(files)
+                    .toTypedArray()
+            proguardFiles(*files)
         }
     }
     testOptions {


### PR DESCRIPTION
https://github.com/DroidKaigi/conference-app-2018/pull/561

・proguardの設定が間違っていてアプリ起動時に落ちる問題の修正

setProguardFilesでは以下のように、すでに設定済みのproguardファイルリストを消しているので、代わりにproguardFiles(Object... files)を使うように変更しました

``` java
public BuildType setProguardFiles(Iterable<?> proguardFileIterable) 
    this.checkPostprocessingConfiguration(BuildType.PostprocessingConfiguration.OLD_DSL, "setProguardFiles");
    this.getProguardFiles().clear();
    this.proguardFiles(Iterables.toArray(proguardFileIterable, Object.class));
    return this;
}
```

手元では良さそうだったので確認お願いします！
forkしたリポジトリから別のforkされたリポジトリにプルリクをちゃんと送れていなかったらすみません・・・
